### PR TITLE
adding nosebook-match-cell

### DIFF
--- a/Automation.ipynb
+++ b/Automation.ipynb
@@ -48,7 +48,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Generate `README.rst` from `README.ipynb`"
+    "### Generate `README.md` from `README.ipynb`"
    ]
   },
   {
@@ -59,7 +59,7 @@
    },
    "outputs": [],
    "source": [
-    "!ipython nbconvert README.ipynb --to=rst"
+    "!ipython nbconvert README.ipynb --to=markdown"
    ]
   },
   {

--- a/README.ipynb
+++ b/README.ipynb
@@ -27,7 +27,7 @@
     "## How does it work?\n",
     "Each notebook found according to [`nosebook-match`](#nosebook-match) is started with a fresh kernel, based on the kernel specified in the notebook. If the kernel is not installed, no tests will be run and the error will be logged.\n",
     "\n",
-    "Each `code` cell will be executed against the kernel in the order in which it appears in the notebook: other cells e.g. `markdown`, `raw`, are ignored.\n",
+    "Each `code` cell that matches [`nosebook-match-cell`](#nosebook-match-cell) will be executed against the kernel in the order in which it appears in the notebook: other cells e.g. `markdown`, `raw`, are ignored.\n",
     "\n",
     "The number and content of outputs has to __match exactly__, with the following parts of each output stripped:\n",
     "\n",
@@ -42,7 +42,7 @@
    "metadata": {},
    "source": [
     "## Related work\n",
-    "- [`ipython_nose`](http://github.com/taavi/ipython_nose) allows you to use a notebook as a nose runner, with traditional `test_whatever` methods."
+    "- [`ipython_nose`](http://github.com/taavi/ipython_nose) allows you to use a notebook as a nose runner, with traditional `test_whatever` methods. You can sort of emulate this behavior with [`nosebook-match-cell`](#nosebook-match-cel)... as long as you check in passing tests!"
    ]
   },
   {
@@ -93,8 +93,30 @@
    },
    "outputs": [],
    "source": [
-    "# Run against all notebooks... probably not a good idea\n",
+    "# Run against all notebooks... probably not a good idea, but maybe a great idea\n",
     "!nosetests --with-nosebook --nosebook-match .*.ipynb"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### `nosebook-match-cell`\n",
+    "A regular expression that will be replaced throughout the expected outputs and generated outputs.\n",
+    "\n",
+    "_Default: None_"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# will run cells where tests are defined... but you should probably run them, too\n",
+    "!nosetests --with-nosebook --nosebook-match .*Simple.* --nosebook-match-cell '(def|class).*[Tt]est'"
    ]
   },
   {

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This makes it ideal for decreasing the burden of keeping documentation up to dat
 ## How does it work?
 Each notebook found according to [`nosebook-match`](#nosebook-match) is started with a fresh kernel, based on the kernel specified in the notebook. If the kernel is not installed, no tests will be run and the error will be logged.
 
-Each `code` cell will be executed against the kernel in the order in which it appears in the notebook: other cells e.g. `markdown`, `raw`, are ignored.
+Each `code` cell that matches [`nosebook-match-cell`](#nosebook-match-cell) will be executed against the kernel in the order in which it appears in the notebook: other cells e.g. `markdown`, `raw`, are ignored.
 
 The number and content of outputs has to __match exactly__, with the following parts of each output stripped:
 
@@ -27,7 +27,7 @@ The number and content of outputs has to __match exactly__, with the following p
 Non-deterministic output, such as with `_repr_` methods that include the memory location of the instance, will obviously not match every time. You can use [`nosebook-scrub`](#nosebook-scrub) to rewrite or remove offending content.
 
 ## Related work
-- [`ipython_nose`](http://github.com/taavi/ipython_nose) allows you to use a notebook as a nose runner, with traditional `test_whatever` methods.
+- [`ipython_nose`](http://github.com/taavi/ipython_nose) allows you to use a notebook as a nose runner, with traditional `test_whatever` methods. You can sort of emulate this behavior with [`nosebook-match-cell`](#nosebook-match-cel)... as long as you check in passing tests!
 
 ## Configuring `nosetests` to use `nosebook`
 These options can be specified in your [nose config file](./.noserc), or as long-form command line arguments, i.e. `--with-nosebook`.
@@ -47,8 +47,17 @@ A regular expression that tells nosebook what should be a testable notebook.
 _Default: `.*[Tt]est.*.ipynb$`_
 
 
-    # Run against all notebooks... probably not a good idea
+    # Run against all notebooks... probably not a good idea, but maybe a great idea
     !nosetests --with-nosebook --nosebook-match .*.ipynb
+
+#### `nosebook-match-cell`
+A regular expression that will be replaced throughout the expected outputs and generated outputs.
+
+_Default: None_
+
+
+    # will run cells where tests are defined... but you should probably run them, too
+    !nosetests --with-nosebook --nosebook-match .*Simple.* --nosebook-match-cell '(def|class).*[Tt]est'
 
 #### `nosebook-scrub`
 A regular expression that will be replaced throughout the expected outputs and generated outputs.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,3 @@
 -r requirements.txt
 flake8
 wheel
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 nose>=1.3.4
-IPython>=3.0.0b1
+IPython>=3.0.0
 jsonschema
 pyzmq

--- a/tests/Test Simple.ipynb
+++ b/tests/Test Simple.ipynb
@@ -25,7 +25,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 1,
    "metadata": {
     "collapsed": true
    },
@@ -43,7 +43,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 2,
    "metadata": {
     "collapsed": false
    },
@@ -54,7 +54,7 @@
        "2"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -72,7 +72,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 3,
    "metadata": {
     "collapsed": false
    },
@@ -98,7 +98,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 4,
    "metadata": {
     "collapsed": false
    },
@@ -116,7 +116,7 @@
        "2"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -135,7 +135,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 5,
    "metadata": {
     "collapsed": false
    },
@@ -147,7 +147,7 @@
      "traceback": [
       "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
       "\u001b[1;31mZeroDivisionError\u001b[0m                         Traceback (most recent call last)",
-      "\u001b[1;32m<ipython-input-25-b761d17a0499>\u001b[0m in \u001b[0;36m<module>\u001b[1;34m()\u001b[0m\n\u001b[1;32m----> 1\u001b[1;33m \u001b[1;36m0\u001b[0m \u001b[1;33m/\u001b[0m \u001b[1;36m0\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[1;32m<ipython-input-5-b761d17a0499>\u001b[0m in \u001b[0;36m<module>\u001b[1;34m()\u001b[0m\n\u001b[1;32m----> 1\u001b[1;33m \u001b[1;36m0\u001b[0m \u001b[1;33m/\u001b[0m \u001b[1;36m0\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m",
       "\u001b[1;31mZeroDivisionError\u001b[0m: division by zero"
      ]
     }
@@ -165,7 +165,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 6,
    "metadata": {
     "collapsed": false
    },
@@ -184,7 +184,7 @@
      "traceback": [
       "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
       "\u001b[1;31mZeroDivisionError\u001b[0m                         Traceback (most recent call last)",
-      "\u001b[1;32m<ipython-input-27-5947a2d28144>\u001b[0m in \u001b[0;36m<module>\u001b[1;34m()\u001b[0m\n\u001b[0;32m      1\u001b[0m \u001b[0mprint\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;36m1\u001b[0m \u001b[1;33m+\u001b[0m \u001b[1;36m1\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m----> 2\u001b[1;33m \u001b[1;36m0\u001b[0m\u001b[1;33m/\u001b[0m\u001b[1;36m0\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[1;32m<ipython-input-6-5947a2d28144>\u001b[0m in \u001b[0;36m<module>\u001b[1;34m()\u001b[0m\n\u001b[0;32m      1\u001b[0m \u001b[0mprint\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;36m1\u001b[0m \u001b[1;33m+\u001b[0m \u001b[1;36m1\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m----> 2\u001b[1;33m \u001b[1;36m0\u001b[0m\u001b[1;33m/\u001b[0m\u001b[1;36m0\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m",
       "\u001b[1;31mZeroDivisionError\u001b[0m: division by zero"
      ]
     }
@@ -210,7 +210,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 7,
    "metadata": {
     "collapsed": false
    },
@@ -224,7 +224,7 @@
        "<IPython.core.display.HTML object>"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -242,7 +242,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 8,
    "metadata": {
     "collapsed": false
    },
@@ -275,6 +275,32 @@
    "source": [
     "display.display(display.HTML(\"<h1>Some Other HTML</h1>\"))\n",
     "display.display(display.HTML(\"<h2>Yet Other HTML</h2>\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "ename": "AssertionError",
+     "evalue": "",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[1;31mAssertionError\u001b[0m                            Traceback (most recent call last)",
+      "\u001b[1;32m<ipython-input-9-561e3f1e80c7>\u001b[0m in \u001b[0;36m<module>\u001b[1;34m()\u001b[0m\n\u001b[0;32m      1\u001b[0m \u001b[1;32mdef\u001b[0m \u001b[0mtest_a_thing\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m      2\u001b[0m     \u001b[1;32massert\u001b[0m \u001b[1;36m1\u001b[0m \u001b[1;33m==\u001b[0m \u001b[1;36m0\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m----> 3\u001b[1;33m \u001b[0mtest_a_thing\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[1;32m<ipython-input-9-561e3f1e80c7>\u001b[0m in \u001b[0;36mtest_a_thing\u001b[1;34m()\u001b[0m\n\u001b[0;32m      1\u001b[0m \u001b[1;32mdef\u001b[0m \u001b[0mtest_a_thing\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m----> 2\u001b[1;33m     \u001b[1;32massert\u001b[0m \u001b[1;36m1\u001b[0m \u001b[1;33m==\u001b[0m \u001b[1;36m0\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m      3\u001b[0m \u001b[0mtest_a_thing\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;31mAssertionError\u001b[0m: "
+     ]
+    }
+   ],
+   "source": [
+    "def test_a_thing():\n",
+    "    assert 1 == 0\n",
+    "test_a_thing()"
    ]
   }
  ],

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -12,6 +12,10 @@ def match(pattern):
     return "--nosebook-match=.*%s.*" % pattern
 
 
+def match_cell(pattern):
+    return "--nosebook-match-cell=%s" % pattern
+
+
 def scrub(patterns):
     return "--nosebook-scrub=%s" % json.dumps(patterns)
 
@@ -68,6 +72,13 @@ class TestScrubStr(TestNosebook):
         match("Scrubbing"),
         scrub("((a|some other) random number <0x0\.\d*>)|"
               "<(.*) at 0x[0-9a-f]+>")
+    ] + OTHER_ARGS
+
+
+class TestMatchCell(TestNosebook):
+    args = [
+        match("Test"),
+        match_cell("^\s*(class|def) .*[tT]est.*")
     ] + OTHER_ARGS
 
 


### PR DESCRIPTION
To halfway meet the use case in #9  (use nosebook for more traditional unit testing) this PR adds `nosebook-match-cell`, a new command line argument to allow specifying a pattern to require cells.

By default, it matches everything, so the default behaviour will not change.

By setting it to `^\s*(def|class).*[tT]est`, one can loosely match the behaviour of `ipython_nose`... though you have to call/instantiate your function/class in the same cell. Of course, you still have to check in a notebook with a passing test output :)