### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,9 +17,9 @@ rich, multi-format documentation and a simple part of your test suite.
 
 .. |Build Status| image:: https://travis-ci.org/bollwyvl/nosebook.svg?branch=master
    :target: https://travis-ci.org/bollwyvl/nosebook
-.. |PyPI| image:: https://pypip.in/version/nosebook/badge.svg?style=flat
+.. |PyPI| image:: https://img.shields.io/pypi/v/nosebook.svg?style=flat
    :target: https://pypi.python.org/pypi/nosebook
-.. |BSD| image:: https://pypip.in/license/nose-watcher/badge.svg
+.. |BSD| image:: https://img.shields.io/pypi/l/nose-watcher.svg
    :target: ./LICENSE
 
 How does it work?


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20nosebook))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `nosebook`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.